### PR TITLE
fix: specify llm model name to fix deprecated errors

### DIFF
--- a/examples/sales_agent_with_context.ipynb
+++ b/examples/sales_agent_with_context.ipynb
@@ -250,7 +250,7 @@
    "source": [
     "# test the intermediate chains\n",
     "verbose=True\n",
-    "llm = ChatLiteLLM(temperature=0.9)\n",
+    "llm = ChatLiteLLM(temperature=0.9, model_name=\"gpt-3.5-turbo\")\n",
     "\n",
     "stage_analyzer_chain = StageAnalyzerChain.from_llm(llm, verbose=verbose)\n",
     "\n",
@@ -447,7 +447,7 @@
     "    text_splitter = CharacterTextSplitter(chunk_size=10, chunk_overlap=0)\n",
     "    texts = text_splitter.split_text(product_catalog)\n",
     "\n",
-    "    llm = OpenAI(temperature=0)\n",
+    "    llm = OpenAI(temperature=0, model_name=\"gpt-3.5-turbo\")\n",
     "    embeddings = OpenAIEmbeddings()\n",
     "    docsearch = Chroma.from_texts(\n",
     "        texts, embeddings, collection_name=\"product-knowledge-base\"\n",


### PR DESCRIPTION
This PR fix the deprecated error: `The model 'text-davinci-003' has been deprevated`

<img width="1302" alt="Screenshot 2024-01-21 at 5 09 34 PM" src="https://github.com/filip-michalsky/SalesGPT/assets/83634399/a9c2c357-ae86-4b0f-b96f-657ca19b2ce7">

